### PR TITLE
add the seedmock data plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,10 @@ Shared by people out of love, for the community. No guarantees.
 
   Deploys changesets, updates state and country picklists and other helpful time-savers. 
 
+- [sedmockdata] (https://github.com/msrivastav13/testdata)
+
+  A plugin for Salesforce DX CLI that provides ability to generate test data using mockaroo schema.You will need to sign up for the mockaroo API services and generate a schema.
+
 ## Not plugins, but useful
 
 - [yo-sfdx-commands-generator](https://github.com/vyuvalv/yo-sfdx-commands-generator) (Yuval Vardi) [](https://github.com/vyuvalv)

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Shared by people out of love, for the community. No guarantees.
 
   Deploys changesets, updates state and country picklists and other helpful time-savers. 
 
-- [sedmockdata] (https://github.com/msrivastav13/testdata)
+- [sedmockdata](https://github.com/msrivastav13/testdata) (Mohith Shrivastava, [@msrivastav13](https://github.com/msrivastav13))
 
   A plugin for Salesforce DX CLI that provides ability to generate test data using mockaroo schema.You will need to sign up for the mockaroo API services and generate a schema.
 


### PR DESCRIPTION
This plugin was built for a Trailhead Live Session (https://sforce.co/36klK1n).

It allows salesforce devs to generate some mock data using mockaroo(https://mockaroo.com/) schema and API.

It allows salesforce devs to generate sample test data using schema created in mockaroo.